### PR TITLE
Show current shortcut in Settings.  Add options to leave windows in current position, focus new window.

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -89,9 +89,10 @@ ul {
 	list-style-type: none;
 }
 
-#default {
-	font-size: 15px;
-	margin: 0;
+#shortcut {
+	font-size: 18px;
+	margin-top: 0px;
+	margin-bottom: 8px;
 }
 
 #sub {

--- a/css/options.css
+++ b/css/options.css
@@ -85,10 +85,6 @@ label, input {
 	margin-bottom: 15px;
 }
 
-label {
-	width: 60px;
-}
-
 ul {
 	list-style-type: none;
 }

--- a/js/options.js
+++ b/js/options.js
@@ -191,8 +191,19 @@
 		add_input_handlers();
 		setup_windows();
 
+		chrome.commands.getAll(function(cmds) {
+			var shortcut = "";
+			if (cmds.length > 0) {
+				shortcut = cmds[0].shortcut;
+			}
+			if (shortcut != "") {
+				$('#shortcut').html("Current Shortcut: " + shortcut);
+			}
+		});
+
 		$('.window').trigger('resize');
 		$('#extensions').click(open_extensions);
 		$('#sub').click(save_options);
+
 	});
 }());

--- a/js/options.js
+++ b/js/options.js
@@ -5,8 +5,8 @@
 
 	var winGrid = 20; // px to use for window grid
 	var defaults = {
-		"original": {width: 50, height: 100, left: 0, top: 0},
-		"new": {width: 50, height: 100, left: 50, top: 0}
+		"original": {resize: false, focus: false, width: 50, height: 100, left: 0, top: 0},
+		"new": {resize: false, width: 50, height: 100, left: 50, top: 0}
 	};
 
 	function restore_options() {
@@ -24,7 +24,12 @@
 							value = defaults[wKey][pKey];
 						}
 
-						input.value = value;
+						// Set checkbox state or parameter value
+						if (value == "true" || value == "false") {
+							input.checked = (value == "true");
+						} else {
+							input.value = value;
+						}
 					}
 				}
 			}
@@ -32,15 +37,21 @@
 	}
 
 	function save_options(event) {
-		var inputs = document.getElementsByClassName('option'),
+		var numericInputs = document.getElementsByClassName('option number'),
+			checkboxInputs = document.getElementsByClassName('option checkbox'),
 			submit = document.getElementById('sub'),
 			valid = true,
 			i;
 
 		// Save to Local Storage
-		for (i = 0; i < inputs.length; i++) {
-			if (inputs[i].checkValidity()) {
-				localStorage['ttw_' + inputs[i].id] = inputs[i].valueAsNumber;
+		for (i = 0; i < numericInputs.length; i++) {
+			if (numericInputs[i].checkValidity()) {
+				localStorage['ttw_' + numericInputs[i].id] = numericInputs[i].valueAsNumber;
+			}
+		}
+		for (i = 0; i < checkboxInputs.length; i++) {
+			if (checkboxInputs[i].checkValidity()) {
+				localStorage['ttw_' + checkboxInputs[i].id] = checkboxInputs[i].checked;
 			}
 		}
 	}
@@ -82,6 +93,7 @@
 
 		for (i = 0; i < inputs.length; i++) {
 			inputs[i].oninput = make_oninput_handler();
+			inputs[i].onchange = make_oninput_handler();
 			inputs[i].oninvalid = make_oninvalid_handler();
 		}
 	}

--- a/js/ttw.js
+++ b/js/ttw.js
@@ -1,8 +1,29 @@
+var defaults = {
+	"original": {resize: false, focus: false, width: 0.5, height: 1, left: 0, top: 0, min_top: 0},
+	"new": {resize: false, width: 0.5, height: 1, left: 0.5, top: 0, min_top: 0}
+};
+
+function get_resize_toggle(key) {
+	var resize = localStorage['ttw_' + key + '-resize'];
+	// If unset, return default
+	if (typeof resize === "undefined") {
+		return defaults[key]['resize'];
+	} else {
+		return resize === "true";
+	}
+}
+
+function get_focus_original_toggle() {
+	var focus = localStorage['ttw_original-focus'];
+	// If unset, return default
+	if (typeof focus === "undefined") {
+		return defaults['original']['focus'];
+	} else {
+		return focus === "true";
+	}
+}
+
 function get_size_and_pos(key) {
-	var defaults = {
-		"original": {width: 0.5, height: 1, left: 0, top: 0, min_top: 0},
-		"new": {width: 0.5, height: 1, left: 0.5, top: 0, min_top: 0}
-	};
 	var properties = {
 		width : localStorage['ttw_' + key + '-width'],
 		height : localStorage['ttw_' + key + '-height'],
@@ -49,45 +70,83 @@ function get_size_and_pos(key) {
 }
 
 function position_original(id) {
-	var vals = get_size_and_pos('original');
+	// Position the original window iff the user specified to
+	if (get_resize_toggle('original')) {
+		var vals = get_size_and_pos('original');
 
-	// Move original window
-	chrome.windows.update(id, {
-		width: vals['width'],
-		height: vals['height'],
-		left: vals['left'],
-		top: vals['top']
-	});
+		// Move original window
+		chrome.windows.update(id, {
+			width: vals['width'],
+			height: vals['height'],
+			left: vals['left'],
+			top: vals['top']
+		});
+	}
 }
 
-function create_new_window(original_id) {
+function create_new_window(original_id, callback) {
 	// Get active tab
 	chrome.tabs.query({
 		currentWindow: true,
 		active:true
 	}, function (tabs) {
-		var vals = get_size_and_pos('new');
-
-		// Move it to a new window
-		chrome.windows.create({
-			tabId: tabs[0].id,
-			width: vals['width'],
-			height: vals['height'],
-			left: vals['left'],
-			top: vals['top'],
-			incognito: tabs[0].incognito
-		}, function () {
-			chrome.windows.update(original_id, {
-				focused: true
+		
+		var setupWindow = function(windowParams, updateParams) {
+			// Move the tab to a new window, focussing the new or old window
+			chrome.windows.create(windowParams, function (newWindow) {
+				if (typeof updateParams === "undefined") {
+					updateParams = {};
+				}
+				chrome.windows.update(newWindow.id, updateParams, function() {
+					if (get_focus_original_toggle()) {
+						chrome.windows.update(original_id, updateParams, function() {
+							callback();
+						});
+					} else {
+						callback();
+					}
+				});
 			});
-		});
+		};
+
+		if (get_resize_toggle('new')) {
+
+			var vals = get_size_and_pos('new');
+			
+			setupWindow({
+				tabId: tabs[0].id,
+				width: vals['width'],
+				height: vals['height'],
+				left: vals['left'],
+				top: vals['top'],
+				incognito: tabs[0].incognito,
+			});
+
+		} else {
+
+			chrome.windows.get(original_id, function (originalWindow) {
+				setupWindow({
+					tabId: tabs[0].id,
+					width: originalWindow.width,
+					height: originalWindow.height,
+					left: originalWindow.left,
+					top: originalWindow.top,
+					incognito: tabs[0].incognito,
+				}, {
+					state: originalWindow.state,
+				});
+			});
+
+		}
+
 	});
 }
 
 function move_windows() {
 	chrome.windows.getCurrent({}, function (window) {
-		position_original(window.id);
-		create_new_window(window.id);
+		create_new_window(window.id, function() {
+			position_original(window.id);
+		});
 	});
 }
 

--- a/options.html
+++ b/options.html
@@ -9,8 +9,7 @@
 	<body>
 		<div id="container">
 			<h1>Tab To Window Keyboard Shortcut</h1>
-			<h2>Default Command:</h2>
-			<p id="default">Alt + Shift + W</p>
+			<p id="shortcut">Default Command: Alt + Shift + W</p>
 			<div id="monitor">
 				<div id="screen">
 					<div id="original" class="window ui-widget-content">

--- a/options.html
+++ b/options.html
@@ -32,34 +32,45 @@
 				<div class="options-section">
 					<h3>Original window size</h3>
 					<label for="original-width">Width:</label>
-					<input id="original-width" class="option" name="original-width" type="number" value="50" min="20" max="100" step="5">%
+					<input id="original-width" class="option number" name="original-width" type="number" value="50" min="20" max="100" step="5">%
 					<br>
 					<label for="original-height">Height:</label>
-					<input id="original-height" class="option" name="original-height" type="number" value="50" min="20" max="100" step="5">%
+					<input id="original-height" class="option number" name="original-height" type="number" value="50" min="20" max="100" step="5">%
 					<h3>Original window position</h3>
 					<label for="original-left">Left:</label>
-					<input id="original-left" class="option" name="original-left" type="number" value="50" min="0" max="100" step="5">%
+					<input id="original-left" class="option number" name="original-left" type="number" value="50" min="0" max="100" step="5">%
 					<br>
 					<label for="original-top">Top:</label>
-					<input id="original-top" class="option" name="original-top" type="number" value="0" min="0" max="100" step="5">%
+					<input id="original-top" class="option number" name="original-top" type="number" value="0" min="0" max="100" step="5">%
 				</div>
 				<div class="options-section">
 					<h3>New window size</h3>
 					<label for="new-width">Width:</label>
-					<input id="new-width" class="option" name="new-width" type="number" value="50" min="1" max="100">%
+					<input id="new-width" class="option number" name="new-width" type="number" value="50" min="1" max="100">%
 					<br>
 					<label for="new-height">Height:</label>
-					<input id="new-height" class="option" name="new-height" type="number" value="50" min="1" max="100">%
+					<input id="new-height" class="option number" name="new-height" type="number" value="50" min="1" max="100">%
 					<h3>New window position</h3>
 					<label for="new-left">Left:</label>
-					<input id="new-left" class="option" name="new-left" type="number" value="50" min="0" max="100">%
+					<input id="new-left" class="option number" name="new-left" type="number" value="50" min="0" max="100">%
 					<br>
 					<label for="new-top">Top:</label>
-					<input id="new-top" class="option" name="new-top" type="number" value="0" min="0" max="100">%
+					<input id="new-top" class="option number" name="new-top" type="number" value="0" min="0" max="100">%
 				</div>
 				<input id="sub" type="submit" value="Save">
 			</form>
 			<p id="resize-note">Windows are resizable from all sides.</p>
+			<br>
+			<div class="options-section">
+				<label for="original-resize">Move and resize original window:</label>
+				<input id="original-resize" class="option checkbox" name="original-resize" type="checkbox" checked="false">
+				<br>
+				<label for="new-resize">Move and resize new window:</label>
+				<input id="new-resize" class="option checkbox" name="new-resize" type="checkbox" checked="false">
+				<br>
+				<label for="original-focus">Keep focus on original window:</label>
+				<input id="original-focus" class="option checkbox" name="original-focus" type="checkbox" checked="false">
+			</div>
 		</div>
 		<div id="note">
 			<h4>Changing the key command:</h4>


### PR DESCRIPTION
Hey - this extension was almost everything I was looking for to get around this shortcoming of Chrome on Windows, but I needed options to leave the base window as it was, and to focus the new window instead.  With those implemented, I also made a quick change to show the current key-binding in the settings menu.  Please go ahead and bring in any changes you like - I suspect they're useful additions to the extension. ~ James