### PR TITLE
Add options for popup and focus

### DIFF
--- a/css/options.css
+++ b/css/options.css
@@ -27,7 +27,7 @@ body {
 	font-family:'Oxygen', sans-serif;
 }
 
-#container, #note, #credit {
+#container, #note, #credit, #optcheckbox {
 	width: 408px;
 	margin: 0 auto;
 }
@@ -105,6 +105,14 @@ ul {
 #credit {
 	font-size: 14px;
 	margin-top: 10px;
+}
+
+#optcheckbox {
+	/* TODO: learn css :) */
+	font-size: 14px;
+	font-weight: bold;
+	margin-top: 20px;
+	width: 37%;
 }
 
 #monitor, .inner-window {

--- a/js/options.js
+++ b/js/options.js
@@ -43,11 +43,9 @@
 			valid = true,
 			i;
 
-		var popupCheck = document.getElementById('popupTab');
+		// popupTab and focusNew directly from dom
 		localStorage['ttw_popupTab'] = popupTab.checked;
-
-		var focusCheck = document.getElementById('focusNew');
-		localStorage['ttw_focusNew'] = focusCheck.checked;
+		localStorage['ttw_focusNew'] = focusNew.checked;
 
 		// Save to Local Storage
 		for (i = 0; i < inputs.length; i++) {

--- a/js/options.js
+++ b/js/options.js
@@ -12,11 +12,10 @@
 	function restore_options() {
 		var wKey, pKey, id, input, value;
 
-		input = document.getElementById("popupTab");
-		input.checked = localStorage['ttw_popupTab'] == 'true';
-
-		input = document.getElementById("focusNew");
-		input.checked = localStorage['ttw_focusNew'] == 'true';
+		// popupTab and focusNew directly from dom
+		// ...works, but should I be doing document.getElementById ?
+		popupTab.checked = localStorage['ttw_popupTab'] == 'true';
+		focusNew.checked = localStorage['ttw_focusNew'] == 'true';
 
 		for (wKey in defaults) {
 			if (defaults.hasOwnProperty(wKey)) {

--- a/js/options.js
+++ b/js/options.js
@@ -12,6 +12,12 @@
 	function restore_options() {
 		var wKey, pKey, id, input, value;
 
+		input = document.getElementById("popupTab");
+		input.checked = localStorage['ttw_popupTab'] == 'true';
+
+		input = document.getElementById("focusNew");
+		input.checked = localStorage['ttw_focusNew'] == 'true';
+
 		for (wKey in defaults) {
 			if (defaults.hasOwnProperty(wKey)) {
 				for (pKey in defaults[wKey]) {
@@ -36,6 +42,12 @@
 			submit = document.getElementById('sub'),
 			valid = true,
 			i;
+
+		var popupCheck = document.getElementById('popupTab');
+		localStorage['ttw_popupTab'] = popupTab.checked;
+
+		var focusCheck = document.getElementById('focusNew');
+		localStorage['ttw_focusNew'] = focusCheck.checked;
 
 		// Save to Local Storage
 		for (i = 0; i < inputs.length; i++) {
@@ -182,5 +194,7 @@
 		$('.window').trigger('resize');
 		$('#extensions').click(open_extensions);
 		$('#sub').click(save_options);
+		$('#popupTab').click(save_options);
+		$('#focusNew').click(save_options);
 	});
 }());

--- a/js/ttw.js
+++ b/js/ttw.js
@@ -68,6 +68,11 @@ function create_new_window(original_id) {
 	}, function (tabs) {
 		var vals = get_size_and_pos('new');
 
+		var wintype = 'normal';
+		if (localStorage['ttw_popupTab'] == "true") {
+			wintype = 'popup';
+		}
+
 		// Move it to a new window
 		chrome.windows.create({
 			tabId: tabs[0].id,
@@ -75,11 +80,16 @@ function create_new_window(original_id) {
 			height: vals['height'],
 			left: vals['left'],
 			top: vals['top'],
+			type: wintype,
 			incognito: tabs[0].incognito
-		}, function () {
-			chrome.windows.update(original_id, {
-				focused: true
-			});
+		}, function (newwin) {
+		   if (localStorage['ttw_focusNew'] !== 'true') {
+				chrome.windows.update(original_id, {
+					focused: true
+				});
+			}
+			// save parent id in case we want to pop_in
+			sessionStorage[newwin.id]=original_id;
 		});
 	});
 }
@@ -91,6 +101,21 @@ function move_windows() {
 	});
 }
 
+function pop_in(outtab, orig_id) {
+	chrome.windows.get(orig_id,{},function(orig_win) {
+		if ( typeof orig_win === "undefined" ) {
+			// not sure this check is required.
+			return;
+		}
+		// Previous window exists
+		// It may be necessary to update current window to "normal" before
+		// move will work.
+		chrome.tabs.move(outtab.id,{
+			windowId: orig_id,
+			index: -1
+			});
+	});
+}
 
 function tab_to_window() {
 	// Check there are more than 1 tabs in current window
@@ -110,7 +135,19 @@ function tab_to_window() {
 				move_windows();
 			}
 		}
+		else {
+			chrome.windows.getCurrent({}, function(curwin) {
+				// If windows was previously popped-out, try and put it back.
+				var orig_id = sessionStorage[curwin.id];
+				if ( typeof orig_id === "undefined" ) {
+					return;
+				}
+				pop_in(tabs[0], +orig_id);
+			});
+		}
 	});
 }
 
 chrome.commands.onCommand.addListener(tab_to_window);
+
+// vim: tabstop=3 shiftwidth=3

--- a/options.html
+++ b/options.html
@@ -61,6 +61,12 @@
 			</form>
 			<p id="resize-note">Windows are resizable from all sides.</p>
 		</div>
+		<div id="optcheckbox">
+			<input type="checkbox" id="popupTab"/>
+			Move tab to popup window<br>
+			<input type="checkbox" id="focusNew"/>
+			Leave focus on new window.
+		</div>
 		<div id="note">
 			<h4>Changing the key command:</h4>
 			<ol>


### PR DESCRIPTION
New option allows tab to be moved to a popup window rather
than a normal browser window.

New option allows focus to remain on new window.

Support pop-in of a window back to a tab in original window.