### PR TITLE
Plus new tab

### DIFF
--- a/js/ttw.js
+++ b/js/ttw.js
@@ -116,16 +116,18 @@ function tab_to_window() {
 //same as previous function but instead of the current tab, 
 function new_tab_to_window() {
 	//create a new tab
-	chrome.tabs.create();
+	chrome.tabs.create({url:"chrome://newtab/"});
 	//then call the normal function with this new tab open
 	tab_to_window();
 }
 
-//calls the main tab to new window function when the user hits the shortcut keys
-chrome.commands.onCommand.addListener(function(command)
+//sets up the listener for the shortcut key
+chrome.commands.onCommand.addListener(function(command_string)
 {
+	console.log("Command triggered: " + command_string);
+
 	//if the command for the new tab first was called, call that
-	if(command_string == "New-tab-First") {
+	if(command_string == "new-tab-first") {
 		new_tab_to_window();
 	} else { //otherwise call the primary action function
 		tab_to_window();

--- a/js/ttw.js
+++ b/js/ttw.js
@@ -113,4 +113,13 @@ function tab_to_window() {
 	});
 }
 
+//same as previous function but instead of the current tab, 
+function new_tab_to_window() {
+	//create a new tab
+	chrome.tabs.create();
+	//then call the normal function with this new tab open
+	tab_to_window();
+}
+
+//calls the main tab to new window function when the user hits the shortcut keys
 chrome.commands.onCommand.addListener(tab_to_window);

--- a/js/ttw.js
+++ b/js/ttw.js
@@ -77,9 +77,10 @@ function create_new_window(original_id) {
 			top: vals['top'],
 			incognito: tabs[0].incognito
 		}, function () {
-			chrome.windows.update(original_id, {
-				focused: true
-			});
+			//chrome.windows.update(original_id, {
+			//	focused: true
+			//});
+			console.log("orig id: " + original_id);
 		});
 	});
 }

--- a/js/ttw.js
+++ b/js/ttw.js
@@ -122,4 +122,12 @@ function new_tab_to_window() {
 }
 
 //calls the main tab to new window function when the user hits the shortcut keys
-chrome.commands.onCommand.addListener(tab_to_window);
+chrome.commands.onCommand.addListener(function(command)
+{
+	//if the command for the new tab first was called, call that
+	if(command_string == "New-tab-First") {
+		new_tab_to_window();
+	} else { //otherwise call the primary action function
+		tab_to_window();
+	}
+});

--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,10 @@
 			"suggested_key": { "default": "Alt+Shift+W" },
 			"description": "Open current tab in new window"
 		}
+		"New-tab-First": {
+			"suggested_key": { "default": "Alt+Shift+T" },
+			"description": "Open a NEW tab in new window"
+		}
 	},
 	"permissions": ["tabs"],
 	"options_page": "options.html"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Tab to Window Keyboard Shortcut",
-	"description": "Add a keyboard shortcut to move the current tab to a new window (default: Alt + Shift + W).",
-	"version": "2.1.1",
+	"description": "Add a keyboard shortcut to move the current tab (or a new tab) to a new window (default: Alt + Shift + W).",
+	"version": "2.2.1",
 	"manifest_version": 2,
 	"minimum_chrome_version": "25",
 
@@ -20,8 +20,8 @@
 		"toggle-feature": {
 			"suggested_key": { "default": "Alt+Shift+W" },
 			"description": "Open current tab in new window"
-		}
-		"New-tab-First": {
+		},
+		"new-tab-first": {
 			"suggested_key": { "default": "Alt+Shift+T" },
 			"description": "Open a NEW tab in new window"
 		}

--- a/options.html
+++ b/options.html
@@ -64,7 +64,7 @@
 		<div id="note">
 			<h4>Changing the key command:</h4>
 			<ol>
-				<li>Go to  <a id="extensions" href="chrome://extensions">chrome://extensions</a></li>
+				<li>Go to  <a id="extensions" href="chrome://extensions/#footer-section">chrome://extensions</a></li>
 				<li>Scroll to the bottom of the page</li>
 				<li>Click 'Configure commands'</li>
 			</ol>


### PR DESCRIPTION
Hi, 
I added an option to create a new tab first, and then run your (awesome!) shortcut. 
Essentially the same as Ctrl + T then your app's shortcut, but all at once.
Since anyone using this is here to save keystrokes, I thought they might be interested (I was!)
Also, I commented out the focusing on the old wind and allow the focus to remain on the new window