### PR TITLE
Auto focus on the popped-back-in tab

### DIFF
--- a/js/ttw.js
+++ b/js/ttw.js
@@ -220,6 +220,9 @@ function window_to_tab() {
 				index:    -1
 			}, function() {
 				sessionStorage.removeItem(popped_key);
+				chrome.tabs.update(tab.id, {
+					active: true
+				});
 			});
 		});
 	});


### PR DESCRIPTION
Because why wouldn't the user want to focus on this tab?

Note: I haven't tested this at all. I just referenced chrome documentation and my own knowledge of Javascript. Otherwise, I love your app!