### PR TITLE
add 'options.showMenu' for page context menu availability

### DIFF
--- a/js/options-page.js
+++ b/js/options-page.js
@@ -29,6 +29,7 @@ function getFocusedName() {
 function save() {
   options.set("focus", getFocusedName());
   options.set("resizeOriginal", getFromId("resize-original").checked);
+  options.set("showMenu", getFromId("show-menu").checked);
   options.set("copyFullscreen", getFromId("copy-fullscreen").checked);
   options.set("cloneMode",  getFromClass("clone-mode-option").find(cp => cp.checked).id);
   options.set("menuButtonType", getFromClass("menu-button-option").find(mb => mb.checked).getAttribute("data-value"));
@@ -113,6 +114,11 @@ function updateFocus() {
   });
 }
 
+function updateShowMenu() {
+  // TODO: show hide context menu
+  // for now save/reload is required
+}
+
 function setWindowAsCurrent(win) {
   getFromClass("window").forEach(_win => {
     _win === win
@@ -185,6 +191,7 @@ function main() {
       opt.checked = opt.id.includes(options.get("focus"));
     });
     getFromId("resize-original").checked = options.get("resizeOriginal");
+    getFromId("show-menu").checked = options.get("showMenu");
     const curCloneOption = getFromClass("clone-mode-option").find(cp =>
       cp.id === options.get("cloneMode"));
     curCloneOption.checked = true;
@@ -252,6 +259,7 @@ function main() {
   // add input handlers
   {
     getFromId("resize-original").onchange = updateResizeOriginal;
+    getFromId("show-menu").onchange = updateShowMenu;
     getFromClass("focus-option").forEach(el => el.onchange = updateFocus);
     getFromTag("input").forEach(el => el.onclick = save);
     getFromId("commandsUrl").onclick = event => {

--- a/js/options-storage.js
+++ b/js/options-storage.js
@@ -22,7 +22,9 @@ const defaults = {
   newWidth:       0.5,
   newHeight:      1.0,
   newLeft:        0.5,
-  newTop:         0.0
+  newTop:         0.0,
+  // whether to show context menu (or create, actually)
+  showMenu:     true
 };
 
 // retrieve the storage key for a particular window property
@@ -61,6 +63,7 @@ function validateOptions(options) {
 
   if (!isValidStringOption("focus", ["original", "new"])) { return false; }
   if (!isValidBoolOption("resizeOriginal")) { return false; }
+  if (!isValidBoolOption("showMenu")) { return false; }
   if (!isValidStringOption("cloneMode", ["clone-mode-no",
                                          "clone-mode-same",
                                          "clone-mode-horizontal",

--- a/js/ttw.js
+++ b/js/ttw.js
@@ -395,7 +395,7 @@ chrome.browserAction.onClicked.addListener(() => {
 // Context Menu Creation
 // Options
 // -------
-async function createMenu() {
+async function createMenu(masterMenuContexts) {
   const commandsPromise = new Promise(resolve => {
     chrome.commands.getAll(commands => resolve(commands));
   });
@@ -414,7 +414,7 @@ async function createMenu() {
     type:     "normal",
     id:       "tab to window",
     title:    `Tab to ${normalCommand.description} ${normalShortcut}`,
-    contexts: ["browser_action", "page"],
+    contexts: masterMenuContexts,
   });
 
   const popupCommand = commands.find(cmd => cmd.name === "02-tab-to-window-popup");
@@ -426,7 +426,7 @@ async function createMenu() {
     type:     "normal",
     id:       "tab to popup",
     title:    `Tab to ${popupCommand.description} ${popupShortcut}`,
-    contexts: ["browser_action", "page"],
+    contexts: masterMenuContexts,
   });
 
   const nextCommand = commands.find(cmd => cmd.name === "03-tab-to-window-next");
@@ -438,7 +438,7 @@ async function createMenu() {
     type:     "normal",
     id:       "tab to next",
     title:    `Tab to ${nextCommand.description} ${nextShortcut}`,
-    contexts: ["browser_action", "page"],
+    contexts: masterMenuContexts,
   });
 
   const displayCommand = commands.find(cmd => cmd.name === "04-tab-to-window-display");
@@ -450,7 +450,7 @@ async function createMenu() {
     type:     "normal",
     id:       "tab to display",
     title:    `Tab to ${displayCommand.description} ${displayShortcut}`,
-    contexts: ["browser_action", "page"],
+    contexts: masterMenuContexts,
   });
 
 
@@ -568,4 +568,4 @@ async function createMenu() {
   });
 }
 
-createMenu();
+createMenu(options.get("showMenu") ? ["browser_action", "page"] : ["browser_action"]);

--- a/options.html
+++ b/options.html
@@ -45,6 +45,11 @@
         <input type="checkbox" id="resize-original">
       </div>
 
+      <div class="option-set">
+        <label for="show-menu">Show Page Context Menu:</label>
+        <input type="checkbox" id="show-menu">
+      </div>
+
       <div class="option-set prefix">
         <span>Focus:</span>
         <label for="focus-original">Original</label>


### PR DESCRIPTION
This adds an option to toggle page context menu:

<img src='https://user-images.githubusercontent.com/610161/42582507-e6d84ff2-8561-11e8-9c74-c06fc0a382b8.png' width='300px' border='1'/>

with this, the main page context menu entry is no longer created.