### PR TITLE
Allow updating original window if it was in full screen

### DIFF
--- a/ts/ttw.ts
+++ b/ts/ttw.ts
@@ -210,6 +210,7 @@ getOptions().then(options => {
             height: vals.height,
             left: vals.left,
             top: vals.top,
+            state: 'normal'
           },
           win => resolve(win),
         );

--- a/ts/ttw.ts
+++ b/ts/ttw.ts
@@ -210,7 +210,7 @@ getOptions().then(options => {
             height: vals.height,
             left: vals.left,
             top: vals.top,
-            state: 'normal'
+            state: "normal"
           },
           win => resolve(win),
         );


### PR DESCRIPTION
in addition to the new sizes, you also need to set the state of the windowState to 'normal'
if it's in full screen, any new size updates will be ignored, which is why this wasn't working before

per docs https://developer.chrome.com/extensions/windows#method-update